### PR TITLE
Return null for non-exist data instead of E_NOTICE

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -19,6 +19,11 @@ class Template
         return call_user_func_array($function, $arguments);
     }
 
+    public function __get($key)
+    {
+        return null;
+    }
+
     public function data(Array $data = null)
     {
         if (!is_null($data)) {

--- a/tests/League/Plates/TemplateTest.php
+++ b/tests/League/Plates/TemplateTest.php
@@ -38,6 +38,11 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($this->template->name));
     }
 
+    public function testNonExistData()
+    {
+        $this->assertNull($this->template->name);
+    }
+
     public function testSetVariable()
     {
         $this->template->name = 'Jonathan';


### PR DESCRIPTION
Currently, non-exist view data will have a E_NOTICE when trying to access it on templates and have to do isset() to check if the view data exist to prevent it. It would be convenient if it return null and suppress the E_NOTICE.
