### PR TITLE
'Translation' functionality

### DIFF
--- a/src/Extension/Translate.php
+++ b/src/Extension/Translate.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace League\Plates\Extension;
+
+class Translate implements ExtensionInterface
+{
+    public $engine;
+    public $template;
+    
+    /**
+     * The translation string
+     * @var array|\ArrayAccess Translation array container
+     */
+    protected $translation = null;
+    
+    /**
+     * Current locale
+     * @var string currently used locale. Usecase language switcher:selected
+     */
+    protected $current = null;
+    
+    /**
+     * Available locales
+     * @var array Array of available locales (['en_US', 'en_GB',...])
+     */
+    protected $locales = null;
+    
+    /**
+     * Used to inject all data in the object
+     * 
+     * @method __construct
+     * @access public
+     * 
+     * @param array|ArrayAccess $translation Array with translations
+     * @param string $current The currently loaded locale (Optional)
+     * @param array $locales Array with available locales (Optional) 
+     */
+    public function __construct($translation, $current = null, $locales = array())
+    {
+        $this->translation = $translation;
+        $this->current = $current;
+        $this->locales = $locales;
+    }
+    
+    /**
+     * Searches for key in the translation specified 
+     * in the constructor and returns its value.
+     * 
+     * @method translate
+     * @access public 
+     * 
+     * @param string $needle The needle that needs to be translated
+     * @return string The value of the $needle or translated string 
+     */
+    public function translate($needle)
+    {
+        if (empty($this->translation)) {
+            return $needle;
+        }
+        
+        if (array_key_exists($needle, $this->translation)) {
+            return $this->translation[$needle];
+        } else {
+            return $needle;
+        }
+    }
+    
+    
+    public function getFunctions()
+    {
+        return array(
+            'translate' => 'translate',
+            'trans'     => 'translate',
+            't'         => 'translate',
+            '__'        => 'translate',
+            'locales'   => 'availableLocales',
+            'current'    => 'locale'
+        );
+    }
+    
+    /**
+     * Exposes available locales to the template
+     * 
+     * Usecase: Language Switcher's flag generation
+     * 
+     * @method availableLocales
+     * @access public
+     * 
+     * @return array An array of all locales passed
+     */
+    public function availableLocales()
+    {
+        return $this->locales;
+    }
+    
+    /**
+     * Getter method to retrieve the currently used locale.
+     * Usecase: Language Switcher currently selected language.
+     * 
+     * @method locale
+     * @access public
+     * 
+     * @return string The current locale in use.
+     */
+    public function locale()
+    {
+        return $this->current;
+    }
+}

--- a/tests/League/Plates/Extension/TranslateTest.php
+++ b/tests/League/Plates/Extension/TranslateTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace League\Plates\Extension;
+
+class TranslateTest extends \PHPUnit_Framework_TestCase {
+    
+    private $testable;
+    
+    protected function setUp()
+    {
+        $translation = array(
+            "foo" => "Bar",
+            "The king is dead" => "Long live the king!"
+        );
+        
+        $locales = array('en_GB', 'en_US');
+        
+        $this->extension = new Translate(
+            $translation,
+            'en_GB',
+            $locales
+        );
+        $this->extension->engine = new \League\Plates\Engine();
+        $this->extension->template = new \League\Plates\Template($this->extension->engine);
+        
+    }
+    
+    public function testCanCreateExtension()
+    {
+        $this->assertInstanceOf('League\Plates\Extension\Translate', $this->extension);
+    }
+
+    public function testGetFunctionsReturnsAnArray()
+    {
+        $this->assertInternalType('array', $this->extension->getFunctions());
+    }
+
+    public function testGetFunctionsReturnsAtLeastOneRecord()
+    {
+        $this->assertTrue(count($this->extension->getFunctions()) > 0);
+    }
+    
+    public function testCurrentLocale()
+    {
+        $this->assertEquals($this->extension->locale(), 'en_GB');
+    }
+    
+    public function testNeedleWithoutSpaces()
+    {
+        $this->assertEquals($this->extension->translate('foo'), 'Bar');
+    }
+    
+    public function testNeedleWithSpaces()
+    {
+        $this->assertSame(
+            $this->extension->translate('The king is dead'),
+            'Long live the king!'
+        );
+    }
+    
+    public function testNonExistingNeedle()
+    {
+        $this->assertEquals($this->extension->translate("PHP"), 'PHP');
+    }
+    
+    public function testLocales()
+    {
+        $this->assertEquals(
+            $this->extension->availableLocales(),
+            array('en_GB', 'en_US')
+        );
+    }
+    
+    public function testEmptyObject()
+    {
+        $extension = new Translate(array());
+        $this->assertEquals($extension->translate("foo"), 'foo');
+        $this->assertEquals($extension->locale(), null);
+        $this->assertEquals($extension->availableLocales(), array());
+    }
+}


### PR DESCRIPTION
Can mimic the functionality of translating the static (and dynamic?) content inside a template. It takes a 1 dimensional array containing key => value. 

**Pros:**
- Separates static from dynamic content. - Links texts, meta content and etc.
- Can help in generating language specific URLs. - The value is set during instantiation, see: https://support.google.com/webmasters/answer/182192?hl=en#1
- Language changing. - All data for a language changing plugin are presented
- Makes templates syntax prettier. (depends on implementation)

**Cons:**
- Is not extendable
- Does not support anything but PHP arrays. (Yet)
- Doesn't do much.
