### PR TITLE
Improved template variable handling

### DIFF
--- a/tests/League/Plates/TemplateTest.php
+++ b/tests/League/Plates/TemplateTest.php
@@ -41,6 +41,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
     public function testSetVariable()
     {
         $this->template->name = 'Jonathan';
+        $this->assertTrue(isset($this->template->name));
         $this->assertTrue($this->template->name === 'Jonathan');
     }
 


### PR DESCRIPTION
PHP magic methods can be used to imitate getting/setting of public variables on objects. This gets rid of the ugly $internal property, which means `$template->internal` is no longer a reserved variable name, and the Template code is a lot clearer.
