### PR TITLE
allow multiple default directories

### DIFF
--- a/src/Template/Directory.php
+++ b/src/Template/Directory.php
@@ -11,7 +11,7 @@ class Directory
 {
     /**
      * Template directory path.
-     * @var string
+     * @var array
      */
     protected $path;
 
@@ -31,11 +31,19 @@ class Directory
      */
     public function set($path)
     {
-        if (!is_null($path) and !is_dir($path)) {
-            throw new LogicException(
-                'The specified path "' . $path . '" does not exist.'
-            );
-        }
+		if (is_null($path)) {
+			$path = array();
+		}else
+		if (!is_array($path)) {
+			$path = array($path);
+		}
+		foreach ($path as $dir) {
+			if (!is_dir($dir)) {
+				throw new LogicException(
+					'The specified path "' . $dir . '" does not exist.'
+				);
+			}
+		}
 
         $this->path = $path;
 

--- a/src/Template/Folders.php
+++ b/src/Template/Folders.php
@@ -35,7 +35,7 @@ class Folders
 
     /**
      * Remove a template folder.
-     * @param  string $name
+     * @param  string  $name
      * @return Folders
      */
     public function remove($name)
@@ -65,7 +65,7 @@ class Folders
 
     /**
      * Check if a template folder exists.
-     * @param  string $name
+     * @param  string  $name
      * @return boolean
      */
     public function exists($name)

--- a/src/Template/Folders.php
+++ b/src/Template/Folders.php
@@ -35,7 +35,7 @@ class Folders
 
     /**
      * Remove a template folder.
-     * @param  string  $name
+     * @param  string $name
      * @return Folders
      */
     public function remove($name)
@@ -65,11 +65,21 @@ class Folders
 
     /**
      * Check if a template folder exists.
-     * @param  string  $name
+     * @param  string $name
      * @return boolean
      */
     public function exists($name)
     {
         return isset($this->folders[$name]);
     }
+
+    /**
+     * Returns all the template's folders.
+     * @return array
+     */
+    public function all()
+    {
+        return $this->folders;
+    }
+
 }

--- a/src/Template/Folders.php
+++ b/src/Template/Folders.php
@@ -73,13 +73,4 @@ class Folders
         return isset($this->folders[$name]);
     }
 
-    /**
-     * Returns all the template's folders.
-     * @return array
-     */
-    public function all()
-    {
-        return $this->folders;
-    }
-
 }

--- a/src/Template/Name.php
+++ b/src/Template/Name.php
@@ -47,7 +47,7 @@ class Name
 
     /**
      * Set the engine.
-     * @param Engine $engine
+     * @param Engine  $engine
      * @return Name
      */
     public function setEngine(Engine $engine)
@@ -68,7 +68,7 @@ class Name
 
     /**
      * Set the original name and parse it.
-     * @param string $name
+     * @param string  $name
      * @return Name
      */
     public function setName($name)
@@ -78,19 +78,14 @@ class Name
         $parts = explode('::', $this->name);
 
         if (count($parts) === 1) {
-
             $this->setFile($parts[0]);
-
         } elseif (count($parts) === 2) {
-
             $this->setFolder($parts[0]);
             $this->setFile($parts[1]);
-
         } else {
-
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. ' .
-                'Do not use the folder namespace seperator "::" more than once.'
+                'Do not use the folder namespace separator "::" more than once.'
             );
         }
 
@@ -108,7 +103,7 @@ class Name
 
     /**
      * Set the parsed template folder.
-     * @param string $folder
+     * @param  string $folder
      * @return Name
      */
     public function setFolder($folder)
@@ -129,13 +124,12 @@ class Name
 
     /**
      * Set the parsed template file.
-     * @param string $file
+     * @param  string $file
      * @return Name
      */
     public function setFile($file)
     {
         if ($file === '') {
-
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. ' .
                 'The template name cannot be empty.'
@@ -166,7 +160,6 @@ class Name
      */
     public function getPath()
     {
-	
         if (is_null($this->folder)) {
             $path = $this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file;
 
@@ -181,11 +174,9 @@ class Name
 			}
 
         } else {
-
             $path = $this->folder->getPath() . DIRECTORY_SEPARATOR . $this->file;
 
             if (!is_file($path) and $this->folder->getFallback() and is_file($this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file)) {
-
                 $path = $this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file;
             }
         }
@@ -211,7 +202,6 @@ class Name
         $directory = $this->engine->getDirectory();
 
         if (is_null($directory)) {
-
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. '.
                 'The default directory has not been defined.'

--- a/src/Template/Name.php
+++ b/src/Template/Name.php
@@ -47,7 +47,7 @@ class Name
 
     /**
      * Set the engine.
-     * @param Engine  $engine
+     * @param  Engine $engine
      * @return Name
      */
     public function setEngine(Engine $engine)
@@ -68,7 +68,7 @@ class Name
 
     /**
      * Set the original name and parse it.
-     * @param string  $name
+     * @param  string $name
      * @return Name
      */
     public function setName($name)

--- a/src/Template/Name.php
+++ b/src/Template/Name.php
@@ -47,7 +47,7 @@ class Name
 
     /**
      * Set the engine.
-     * @param  Engine $engine
+     * @param Engine $engine
      * @return Name
      */
     public function setEngine(Engine $engine)
@@ -68,7 +68,7 @@ class Name
 
     /**
      * Set the original name and parse it.
-     * @param  string $name
+     * @param string $name
      * @return Name
      */
     public function setName($name)
@@ -78,14 +78,19 @@ class Name
         $parts = explode('::', $this->name);
 
         if (count($parts) === 1) {
+
             $this->setFile($parts[0]);
+
         } elseif (count($parts) === 2) {
+
             $this->setFolder($parts[0]);
             $this->setFile($parts[1]);
+
         } else {
+
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. ' .
-                'Do not use the folder namespace separator "::" more than once.'
+                'Do not use the folder namespace seperator "::" more than once.'
             );
         }
 
@@ -103,7 +108,7 @@ class Name
 
     /**
      * Set the parsed template folder.
-     * @param  string $folder
+     * @param string $folder
      * @return Name
      */
     public function setFolder($folder)
@@ -124,12 +129,13 @@ class Name
 
     /**
      * Set the parsed template file.
-     * @param  string $file
+     * @param string $file
      * @return Name
      */
     public function setFile($file)
     {
         if ($file === '') {
+
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. ' .
                 'The template name cannot be empty.'
@@ -160,12 +166,26 @@ class Name
      */
     public function getPath()
     {
+	
         if (is_null($this->folder)) {
             $path = $this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file;
+
+			/* If template does not exists search in any additional folder */	
+			if (!is_file($path)) {
+				foreach ($this->engine->getFolders()->all() as $search_folder) {
+					$path = $search_folder->getPath() . DIRECTORY_SEPARATOR . $this->file;
+					if (is_file($path)) {
+						break;
+					}
+				}
+			}
+
         } else {
+
             $path = $this->folder->getPath() . DIRECTORY_SEPARATOR . $this->file;
 
             if (!is_file($path) and $this->folder->getFallback() and is_file($this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file)) {
+
                 $path = $this->getDefaultDirectory() . DIRECTORY_SEPARATOR . $this->file;
             }
         }
@@ -191,6 +211,7 @@ class Name
         $directory = $this->engine->getDirectory();
 
         if (is_null($directory)) {
+
             throw new LogicException(
                 'The template name "' . $this->name . '" is not valid. '.
                 'The default directory has not been defined.'


### PR DESCRIPTION
Allow the default directory to be a string or an array, allowing multiple default directories to be used.
Internally its always stored as array.
This way is backward compatible.
Closes #59 
