### PR TITLE
Fixed Template->render() exception handling

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -132,9 +132,11 @@ class Template
 
             return $content;
         } catch (LogicException $e) {
-            ob_end_clean();
+            if (ob_get_length() > 0) {
+                ob_end_clean();
+            }
 
-            throw new LogicException($e->getMessage());
+            throw $e;
         }
     }
 


### PR DESCRIPTION
`Template->render()` [calls `ob_get_clean()`](https://github.com/thephpleague/plates/blob/207bf83efbc125c60d0268265005867725059285/src/Template/Template.php#L125) to get the result of rendering the template. According to [the PHP manual page](http://php.net/manual/en/function.ob-get-clean.php) for this function, this is what it does, emphasis mine:

> Gets the current buffer contents and **delete current output buffer**.

After this function is called, [another block](https://github.com/thephpleague/plates/blob/207bf83efbc125c60d0268265005867725059285/src/Template/Template.php#L127-131) is executed to render the layout. Within this block, it's possible for a `LogicException` to be thrown if, for example, the layout template cannot be found. If this happens, there is [a `catch` block](https://github.com/thephpleague/plates/blob/207bf83efbc125c60d0268265005867725059285/src/Template/Template.php#L134-137) to handle it.

There are two problems with this `catch` block:

1. Because the aforementioned call to `ob_get_clean()` deleted the output buffer, the call to `ob_end_clean()` in the `catch` block has no buffer to delete and thus causes a notice to be emitted: ["failed to delete buffer. No buffer to delete."](http://stackoverflow.com/questions/14549110/failed-to-delete-buffer-no-buffer-to-delete)
2. Rather than the existing `LogicException` instance being re-thrown, a new one is being instantiated with the message of the original, causing the trace information associated with the original to be lost. This makes debugging difficult.

This PR applies these corrections:

1. Wraps the `ob_end_clean()` call in a `ob_get_length()` check so that it is only called if needed, avoiding the previously emitted notice.
2. Re-throws the existing `LogicException` instance so that the original trace information is preserved.