### PR TITLE
Ability to easily pass the current context.

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -81,6 +81,16 @@ class Template
     }
 
     /**
+     * Get the current data assigned to the template object.
+     * @param  array $data Optional array of additional data.
+     * @return null
+     */
+    public function context(array $data = array())
+    {
+        return array_merge($this->data, $data);
+    }
+
+    /**
      * Check if the template exists.
      * @return boolean
      */

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -246,4 +246,23 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->template->render(), '&lt;strong&gt;Jonathan&lt;/strong&gt;');
     }
+
+    public function testContext()
+    {
+        $this->template->data(array('name' => 'Jonathan'));
+        $this->assertSame(array('name' => 'Jonathan'), $this->template->context());
+    }
+
+    public function testContextOverridesData()
+    {
+        $this->template->data(array('name' => 'Jonathan'));
+        $this->assertSame(array('name' => 'Jason'), $this->template->context(array('name' => 'Jason')));
+    }
+
+    public function testContextIsNonDestructive()
+    {
+        $this->template->data(array('name' => 'Jonathan'));
+        $this->template->context(array('name' => 'Jason'));
+        $this->assertSame(array('name' => 'Jonathan'), $this->template->context());
+    }
 }


### PR DESCRIPTION
Pass the current context to sub-templates, and non-destructively alter or add data to that context.

Usage:

``` php
$this->render('navbar', $this->context());
$this->insert('partials/form', $this->context(array('action' => 'edit')));
```
