### PR TITLE
Fix: Add missing arguments to docblocks

### DIFF
--- a/src/Extension/Asset.php
+++ b/src/Extension/Asset.php
@@ -41,6 +41,7 @@ class Asset implements ExtensionInterface
 
     /**
      * Register extension function.
+     * @param Engine $engine
      * @return null
      */
     public function register(Engine $engine)

--- a/src/Extension/URI.php
+++ b/src/Extension/URI.php
@@ -40,6 +40,7 @@ class URI implements ExtensionInterface
 
     /**
      * Register extension functions.
+     * @param Engine $engine
      * @return null
      */
     public function register(Engine $engine)


### PR DESCRIPTION
This PR

* [x] adds arguments which are present, but missing from docblocks