### PR TITLE
Fix: Do not encourage to edit composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ Plates is a native PHP template system that's fast, easy to use and easy to exte
 
 Plates is available via Composer:
 
-```json
-{
-    "require": {
-        "league/plates": "3.*"
-    }
-}
+```
+$ composer require league/plates
 ```
 
 ## Documentation


### PR DESCRIPTION
This PR
- [x] updates `README.md` and suggests to require `league/plates` via command line, rather than editing `composer.json` directly
