### PR TITLE
Fix: Do not clean more levels than needed

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -105,6 +105,12 @@ class Template
      */
     public function render(array $data = array())
     {
+        static $startLevel;
+
+        if ($startLevel === null) {
+            $startLevel = ob_get_level();
+        }
+
         try {
             $this->data($data);
 
@@ -132,8 +138,8 @@ class Template
 
             return $content;
         } catch (LogicException $e) {
-            if (ob_get_length() > 0) {
-                ob_end_clean();
+            while (ob_get_level() > $startLevel) {
+                ob_get_clean();
             }
 
             throw $e;


### PR DESCRIPTION
This PR
- [x] cleans only as many levels as needed
### Before

```
$ vendor/bin/phpunit
PHPUnit 4.8.6 by Sebastian Bergmann and contributors.

...............................................................  63 / 130 ( 48%)
.....................................................R..RR..... 126 / 130 ( 96%)
R...

Time: 2.18 seconds, Memory: 12.75Mb

OK, but incomplete, skipped, or risky tests!
Tests: 130, Assertions: 203, Risky: 4.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```
### After

```
$ vendor/bin/phpunit
PHPUnit 4.8.6 by Sebastian Bergmann and contributors.

...............................................................  63 / 130 ( 48%)
............................................................... 126 / 130 ( 96%)
....

Time: 2.28 seconds, Memory: 12.50Mb

OK (130 tests, 203 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```

Follows https://github.com/thephpleague/plates/pull/78.
