### PR TITLE
Fix: Use all the columns

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" columns="max" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="all">
             <directory suffix="Test.php">tests/</directory>


### PR DESCRIPTION
This PR

* [x] uses all the columns when showing the progress of running the tests

### Before

```
$ vendor/bin/phpunit
PHPUnit 4.8.6 by Sebastian Bergmann and contributors.

...............................................................  63 / 130 ( 48%)
.....................................................R..RR..... 126 / 130 ( 96%)
R...

Time: 2.18 seconds, Memory: 12.75Mb

OK, but incomplete, skipped, or risky tests!
Tests: 130, Assertions: 203, Risky: 4.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```

### After

```
$ vendor/bin/phpunit
PHPUnit 4.8.6 by Sebastian Bergmann and contributors.

....................................................................................................................R..RR.....R...

Time: 2.28 seconds, Memory: 12.75Mb

OK, but incomplete, skipped, or risky tests!
Tests: 130, Assertions: 203, Risky: 4.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```
