### PR TITLE
Fix: Direct builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ php:
 matrix:
   allow_failures:
     - php: hhvm
+    
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
This PR

* [x] sends Travis builds to container-based infrastructure
* [x] caches dependencies between builds

:information_desk_person: See http://docs.travis-ci.com/user/migrating-from-legacy.