### PR TITLE
Allow nested templates to inherit data from parent templates

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -210,7 +210,7 @@ class Template
      */
     protected function fetch($name, array $data = array())
     {
-        return $this->engine->render($name, $data);
+        return $this->engine->render($name, array_merge($this->data, $data));
     }
 
     /**
@@ -221,7 +221,7 @@ class Template
      */
     protected function insert($name, array $data = array())
     {
-        echo $this->engine->render($name, $data);
+        echo $this->engine->render($name, array_merge($this->data, $data));
     }
 
     /**

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -190,6 +190,44 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->template->render(), 'Hello World');
     }
 
+    public function testInsertFunctionWithData()
+    {
+        vfsStream::create(
+            array(
+                'template.php' => '<?php $this->insert("inserted", array("foo" => "bar")); ?>',
+                'inserted.php' => 'Hello, <?php echo $foo; ?>',
+            )
+        );
+
+        $this->assertEquals($this->template->render(), 'Hello, bar');
+    }
+
+    public function testInsertFunctionWithMergedData()
+    {
+        vfsStream::create(
+            array(
+                'template.php' => '<?php $this->insert("inserted"); ?>',
+                'inserted.php' => 'Hello, <?php echo $foo; ?>',
+            )
+        );
+
+        $this->template->data(array('foo' => 'bar'));
+        $this->assertEquals($this->template->render(), 'Hello, bar');
+    }
+
+    public function testInsertFunctionWithSameMergedData()
+    {
+        vfsStream::create(
+            array(
+                'template.php' => '<?php $this->insert("inserted", array("foo" => "bazz")); ?>',
+                'inserted.php' => 'Hello, <?php echo $foo; ?>',
+            )
+        );
+
+        $this->template->data(array('foo' => 'bar'));
+        $this->assertEquals($this->template->render(), 'Hello, bazz');
+    }
+
     public function testBatchFunction()
     {
         vfsStream::create(


### PR DESCRIPTION
Allow nested templates to inherit data from parent templates. It will merge inherited data with data array that is provided on method call.