### PR TITLE
Specify the minimum php version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "role": "Developer"
         }
     ],
+    "require" : {
+        "php": ">=5.3"
+    },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mikey179/vfsStream": "~1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require" : {
-        "php": ">=5.3"
+        "php": "^5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
It's a good practice to imply which version of php it requires on composer.json
Based on the .travis.yml file, the minimum php version to run this is 5.3