### PR TITLE
Fix: Collect coverage only on PHP5.6

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,7 +20,7 @@ checks:
 tools:
     external_code_coverage:
         timeout: 600
-        runs: 4
+        runs: 1
     php_code_coverage: false
     php_code_sniffer:
         config:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@ language: php
 
 sudo: false
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7
-  - hhvm
-
 matrix:
   fast_finish: true
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+      env: COLLECT_COVERAGE=true
+    - php: 7
+    - php: hhvm
   allow_failures:
     - php: hhvm
     
@@ -26,8 +26,8 @@ install:
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover=coverage.clover; else phpunit; fi
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+  - if [[ "$COLLECT_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - travis_retry composer self-update
 
 install:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,11 +10,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
This PR
- [x] collects and reports coverage only on PHP5.6
- [x] removes coverage configuration from `phpunit.xml.dist`
- [x] removes the configuration for `xdebug` when we don't need it
