### PR TITLE
Allows to set a layout programmatically.

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -146,7 +146,7 @@ class Template
      * @param  array  $data
      * @return null
      */
-    protected function layout($name, array $data = array())
+    public function layout($name, array $data = array())
     {
         $this->layoutName = $name;
         $this->layoutData = $data;


### PR DESCRIPTION
I wanted to set up a layout programmatically like this:

``` php
$template = $templates->make('mytemplate');
$template->layout('default');
$template->render();
```

Unfortunately the `layout()` method is protected. Any objection to have it public ? So it'll solve solve https://github.com/thephpleague/plates/issues/41 at the same time ?
