### PR TITLE
Make the enconding a optional parameter

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -266,7 +266,7 @@ class Template
             $string = $this->batch($string, $functions);
         }
 
-        return htmlspecialchars($string, $flags, $encoding);
+        return htmlspecialchars($string, $flags, $enconding);
     }
 
     /**

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -251,9 +251,10 @@ class Template
      * Escape string.
      * @param  string      $string
      * @param  null|string $functions
+     * @param  null|string $enconding
      * @return string
      */
-    protected function escape($string, $functions = null)
+    protected function escape($string, $functions = null, $enconding = 'UTF-8')
     {
         static $flags;
 
@@ -265,7 +266,7 @@ class Template
             $string = $this->batch($string, $functions);
         }
 
-        return htmlspecialchars($string, $flags, 'UTF-8');
+        return htmlspecialchars($string, $flags, $encoding);
     }
 
     /**


### PR DESCRIPTION
With this PR, it will be able to choose a enconding when escaping. Default value is UTF-8.
This will fix issue #106 
