### PR TITLE
Allow section content to be appended rather than simply replaced

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -154,10 +154,11 @@ class Template
 
     /**
      * Start a new section block.
-     * @param  string $name
+     * @param  string  $name
+     * @param  boolean $append
      * @return null
      */
-    protected function start($name)
+    protected function start($name, $append = false)
     {
         if ($name === 'content') {
             throw new LogicException(
@@ -165,9 +166,13 @@ class Template
             );
         }
 
+        $sectionContent = $this->section($name, '');
         $this->sections[$name] = '';
 
         ob_start();
+        if ($append) {
+            echo $sectionContent;
+        }
     }
 
     /**

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -119,6 +119,18 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->template->render(), 'Hello World');
     }
 
+    public function testSectionAppend()
+    {
+        vfsStream::create(
+            array(
+                'template.php' => '<?php $this->layout("layout")?><?php $this->start("test") ?>Hello World<?php $this->stop() ?><?php $this->start("test", true) ?>!<?php $this->stop() ?>',
+                'layout.php' => '<?php echo $this->section("test") ?>',
+            )
+        );
+
+        $this->assertEquals($this->template->render(), 'Hello World!');
+    }
+
     public function testStartSectionWithInvalidName()
     {
         $this->setExpectedException('LogicException', 'The section name "content" is reserved.');


### PR DESCRIPTION
This commit adds an $append flag to the start function to allow for
appending content to a section.  Current behavior replaces section
content which is not always the desired behavior.

The reason this sometimes comes into play is that you might have a loop
that needs to append javascript to the end of the main template.  Consider
the following behavior:

```
<?php foreach ($items as $item): ?>
    <?php $this->start('javascript', true); ?>
    <script>
    new DoSomethingWithItem('<?php echo $item; ?>');
    </script>
    <?php $this->end(); ?>
<?php endforeach; ?>
```

In my particular case, I need to add in javascript for each individual chart.  There are ways around this by keeping a copy explicitly of the content but it seems that the behavior should be built in.

The current PR works to solve my needs but would not solve the needs of prepending.  In that case, the method would need to have a flag instead and then the initialization to an empty string would need to happen in stop if it was not yet initialized.
