### PR TITLE
Better Exception Handling

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -101,6 +101,8 @@ class Template
     /**
      * Render the template and layout.
      * @param  array  $data
+     * @throws \Throwable
+     * @throws \Exception
      * @return string
      */
     public function render(array $data = array())
@@ -131,13 +133,22 @@ class Template
             }
 
             return $content;
-        } catch (LogicException $e) {
-            if (ob_get_length() > 0) {
-                ob_end_clean();
-            }
-
-            throw $e;
+        } catch (\Throwable $e) {
+            $this->cleanOutputBuffer($e);
+        } catch (\Exception $e) {
+            $this->cleanOutputBuffer($e);
         }
+    }
+
+    /**
+     * @param \Throwable|\Exception $e
+     * @throws \Throwable
+     * @throws \Exception
+     */
+    private function cleanOutputBuffer($e)
+    {
+        ob_end_clean();
+        throw $e;
     }
 
     /**

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -95,6 +95,17 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         var_dump($this->template->render());
     }
 
+    public function testRenderException()
+    {
+        $this->setExpectedException('Exception', 'error');
+        vfsStream::create(
+            array(
+                'template.php' => '<?php throw new Exception("error"); ?>',
+            )
+        );
+        var_dump($this->template->render());
+    }
+
     public function testLayout()
     {
         vfsStream::create(


### PR DESCRIPTION
- Added exception handling in Template::render to include
  all exceptions or throwables (for php7 support)
- Cleaned output buffer on error always regardless if it has
  data in it. No need to keep it around. It also fixes the Risky
  tests in PHPUnit

I came across this issue when I had a php error with my template. If it's not a LogicException, the output buffering is all messed and prevents proper exception pages to be shown if errors happen within the template files.

Signed-off-by: RJ Garcia <rj@bighead.net>