### PR TITLE
Hash last updated timestamp value for Assets

### DIFF
--- a/docs/extensions/asset.md
+++ b/docs/extensions/asset.md
@@ -18,7 +18,7 @@ The asset extension comes packaged with Plates but is not enabled by default, as
 $engine->loadExtension(new League\Plates\Extension\Asset('/path/to/public/assets/', true));
 ~~~
 
-The first constructor parameter is the file system path of the assets directory. The second is an optional `boolean` parameter that if set to true uses the filename caching method (ie. `file.1373577602.css`) instead of the default query string method (ie. `file.css?v=1373577602`).
+The first constructor parameter is the file system path of the assets directory. The second is an optional `boolean` parameter that if set to true uses the filename caching method (ie. `file.1373577602.css`) instead of the default query string method (ie. `file.css?v=1373577602`). A third optional `boolean` parameter can be added to hash the raw timestamp value (ie. `file.62c0b2bd.css` or `file.css?v=62c0b2bd`).
 
 ## Filename caching
 

--- a/src/Extension/Asset.php
+++ b/src/Extension/Asset.php
@@ -30,14 +30,22 @@ class Asset implements ExtensionInterface
     public $filenameMethod;
 
     /**
+     * Enables hashing for last updated value in filename.
+     * @var boolean
+     */
+    public $hashLastUpdatedValue;
+
+    /**
      * Create new Asset instance.
      * @param string  $path
      * @param boolean $filenameMethod
+     * @param boolean $hashLastUpdatedValue
      */
-    public function __construct($path, $filenameMethod = false)
+    public function __construct($path, $filenameMethod = false, $hashLastUpdatedValue = false)
     {
         $this->path = rtrim($path, '/');
         $this->filenameMethod = $filenameMethod;
+        $this->hashLastUpdatedValue = $hashLastUpdatedValue;
     }
 
     /**
@@ -67,6 +75,10 @@ class Asset implements ExtensionInterface
 
         $lastUpdated = filemtime($filePath);
         $pathInfo = pathinfo($url);
+
+        if ($this->hashLastUpdatedValue) {
+            $lastUpdated = hash('crc32b', $lastUpdated);
+        }
 
         if ($pathInfo['dirname'] === '.') {
             $directory = '';

--- a/tests/Extension/AssetTest.php
+++ b/tests/Extension/AssetTest.php
@@ -17,6 +17,10 @@ class AssetTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets')));
         $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), true));
         $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), false));
+        $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), true, true));
+        $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), true, false));
+        $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), false, true));
+        $this->assertInstanceOf('League\Plates\Extension\Asset', new Asset(vfsStream::url('assets'), false, false));
     }
 
     public function testRegister()
@@ -64,6 +68,18 @@ class AssetTest extends \PHPUnit_Framework_TestCase
 
         $extension = new Asset(vfsStream::url('assets'), true);
         $this->assertTrue($extension->cachedAssetUrl('styles.css') === 'styles.' . filemtime(vfsStream::url('assets/styles.css')) . '.css');
+    }
+
+    public function testCachedAssetUrlUsingHashMethod()
+    {
+        vfsStream::create(
+            array(
+                'styles.css' => '',
+            )
+        );
+
+        $extension = new Asset(vfsStream::url('assets'), false, true);
+        $this->assertTrue($extension->cachedAssetUrl('styles.css') === 'styles.css?v=' . hash('crc32b', filemtime(vfsStream::url('assets/styles.css'))));
     }
 
     public function testFileNotFoundException()


### PR DESCRIPTION
Simply hashes the `$lastUpdated` value in the `cachedAssetUrl()` function. This just makes the outputted value look a little cleaner (`/assets/css/style.css?v=91a772e4` opposed to `/assets/css/style.css?v=1503629394`).

It uses the `crc32b` hashing algorithm, which generates a short 8-char hash and only adds ~`0.003`-`0.0009` seconds per call to the request time.

It can be optionally enabled (off be default) by adding a third `boolean` parameter to the `Asset` class instance call.
```
$engine->loadExtension(new League\Plates\Extension\Asset('/path/to/public/assets/', false, true));
```

Some tests have been added and documentation has also been updated to reflect this.

Thanks!