### PR TITLE
Fix build failing on 5.3 for #172

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: php
 
-matrix:
-  include:
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: nightly
-  allow_failures:
-    - php: nightly
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 
 sudo: false
 


### PR DESCRIPTION
Also added php nightly but as an allowed failure given that scrutinizer-ci doesn't seem to have a code coverage "driver" for it.

The build passes https://travis-ci.org/carbontwelve/plates/builds/308338524

Do you need the code coverage to run for each php version or only on 7.1?