### PR TITLE
Fixed callable type hints where callback type has been used

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -164,7 +164,7 @@ class Engine
     /**
      * Register a new template function.
      * @param  string   $name;
-     * @param  callback $callback;
+     * @param  callable $callback;
      * @return Engine
      */
     public function registerFunction($name, $callback)

--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -18,7 +18,7 @@ class Functions
     /**
      * Add a new template function.
      * @param  string    $name;
-     * @param  callback  $callback;
+     * @param  callable  $callback;
      * @return Functions
      */
     public function add($name, $callback)


### PR DESCRIPTION
There are two phpdoc-level type hints where "callback" has been used instead of "callable".

This makes static code analyzers fail (like phpstan) with an error like this: "Parameter #2 $callback of method League\Plates\Engine::registerFunction() expects League\Plates\callback...".

This PR fixes those typos in order to prevent that.