### PR TITLE
Reverse Ordering #194

### DIFF
--- a/src/Extension/Data/DataExtension.php
+++ b/src/Extension/Data/DataExtension.php
@@ -13,11 +13,11 @@ final class DataExtension implements Plates\Extension
         $c->add('data.template_data', []);
         $c->merge('config', ['merge_parent_data' => true]);
 
-        $plates->unshiftComposers(function($c) {
+        $plates->pushComposers(function($c) {
             return array_filter([
-                'data.perTemplateData' => $c->get('data.template_data') ? perTemplateDataCompose($c->get('data.template_data')) : null,
-                'data.mergeParentData' => $c->get('config')['merge_parent_data'] ? mergeParentDataCompose() : null,
                 'data.addGlobals' => $c->get('data.globals') ? addGlobalsCompose($c->get('data.globals')) : null,
+                'data.mergeParentData' => $c->get('config')['merge_parent_data'] ? mergeParentDataCompose() : null,
+                'data.perTemplateData' => $c->get('data.template_data') ? perTemplateDataCompose($c->get('data.template_data')) : null,
             ]);
         });
 

--- a/src/Extension/Folders/FoldersExtension.php
+++ b/src/Extension/Folders/FoldersExtension.php
@@ -14,13 +14,13 @@ final class FoldersExtension implements Plates\Extension
         $c->add('folders.folders', []);
         $c->wrapStack('path.resolvePath', function($stack, $c) {
             $config = $c;
-            return array_merge([
+            return array_merge($stack, [
                 'folders' => foldersResolvePath(
                     $c->get('folders.folders'),
                     $c->get('config')['folder_separator'],
                     $c->get('fileExists')
                 )
-            ], $stack);
+            ]);
         });
         $c->wrapComposed('path.normalizeName', function($composed, $c) {
             return array_merge($composed, [

--- a/src/Extension/LayoutSections/LayoutSectionsExtension.php
+++ b/src/Extension/LayoutSections/LayoutSectionsExtension.php
@@ -11,8 +11,8 @@ final class LayoutSectionsExtension implements Plates\Extension
         $c = $plates->getContainer();
 
         $c->merge('config', ['default_layout_path' => null]);
-        $c->wrapComposed('compose', function($composed, $c) {
-            return array_merge($composed, ['layoutSections.sections' => sectionsCompose()]);
+        $plates->pushComposers(function($c) {
+            return ['layoutSections.sections' => sectionsCompose()];
         });
         $c->wrap('renderTemplate.factories', function($factories, $c) {
             $default_layout_path = $c->get('config')['default_layout_path'];
@@ -27,11 +27,11 @@ final class LayoutSectionsExtension implements Plates\Extension
             $one_arg = RenderContext\assertArgsFunc(1);
 
             return [
-                'layout' => [$template_args, layoutFunc()],
-                'section' => [$one_arg, sectionFunc()],
-                'start' => [$one_arg, startFunc()],
-                'push' => [$one_arg, startFunc(START_APPEND)],
-                'unshift' => [$one_arg, startFunc(START_PREPEND)],
+                'layout' => [layoutFunc(), $template_args],
+                'section' => [sectionFunc(), $one_arg],
+                'start' => [startFunc(), $one_arg],
+                'push' => [startFunc(START_APPEND), $one_arg],
+                'unshift' => [startFunc(START_PREPEND), $one_arg],
             ];
         });
     }

--- a/src/Extension/Path/PathExtension.php
+++ b/src/Extension/Path/PathExtension.php
@@ -26,16 +26,16 @@ final class PathExtension implements Plates\Extension
             $config = $c->get('config');
             $prefixes = $c->get('path.resolvePath.prefixes');
             return array_filter([
-                'path.relative' =>relativeResolvePath(),
-                'path.ext' => isset($config['ext']) ? extResolvePath($config['ext']) : null,
-                'path.prefix' => $prefixes ? prefixResolvePath($prefixes, $c->get('fileExists')) : null,
                 'path.id' => idResolvePath(),
+                'path.prefix' => $prefixes ? prefixResolvePath($prefixes, $c->get('fileExists')) : null,
+                'path.ext' => isset($config['ext']) ? extResolvePath($config['ext']) : null,
+                'path.relative' => relativeResolvePath(),
             ]);
         });
-        $plates->unshiftComposers(function($c) {
+        $plates->pushComposers(function($c) {
             return [
+                'path.normalizeName' => normalizeNameCompose($c->get('path.normalizeName')),
                 'path.resolvePath' => resolvePathCompose($c->get('path.resolvePath')),
-                'path.normalizeName' => normalizeNameCompose($c->get('path.normalizeName'))
             ];
         });
     }

--- a/src/Extension/RenderContext/RenderContextExtension.php
+++ b/src/Extension/RenderContext/RenderContextExtension.php
@@ -11,11 +11,11 @@ final class RenderContextExtension implements Plates\Extension
         $c = $plates->getContainer();
         $c->addStack('renderContext.func', function($c) {
             return [
-                'plates' => Plates\Util\stackGroup([
-                    aliasNameFunc($c->get('renderContext.func.aliases')),
-                    splitByNameFunc($c->get('renderContext.func.funcs'))
-                ]),
                 'notFound' => notFoundFunc(),
+                'plates' => Plates\Util\stackGroup([
+                    splitByNameFunc($c->get('renderContext.func.funcs')),
+                    aliasNameFunc($c->get('renderContext.func.aliases')),
+                ]),
             ];
         });
         $c->add('renderContext.func.aliases', [
@@ -29,29 +29,28 @@ final class RenderContextExtension implements Plates\Extension
             $config = $c->get('config');
 
             return [
-                'insert' => [$template_args, insertFunc()],
+                'insert' => [insertFunc(), $template_args],
                 'escape' => [
-                    $one_arg,
                     isset($config['escape_flags'], $config['escape_encoding'])
                         ? escapeFunc($config['escape_flags'], $config['escape_encoding'])
-                        : escapeFunc()
+                        : escapeFunc(),
+                    $one_arg,
                 ],
-                'data' => [assertArgsFunc(0, 1), templateDataFunc()],
+                'data' => [templateDataFunc(), assertArgsFunc(0, 1)],
                 'name' => [accessTemplatePropFunc('name')],
                 'context' => [accessTemplatePropFunc('context')],
-                'component' => [$template_args, componentFunc()],
-                'slot' => [$one_arg, slotFunc()],
+                'component' => [componentFunc(), $template_args],
+                'slot' => [slotFunc(), $one_arg],
                 'end' => [endFunc()]
             ];
         });
-
-        $c->wrapComposed('compose', function($composed, $c) {
-            return array_merge($composed, [
+        $plates->pushComposers(function($c) {
+            return [
                 'renderContext.renderContext' => renderContextCompose(
                     $c->get('renderContext.factory'),
                     $c->get('config')['render_context_var_name']
                 )
-            ]);
+            ];
         });
         $c->add('include.bind', function($c) {
             return renderContextBind($c->get('config')['render_context_var_name']);

--- a/test/unit/extension-path.spec.php
+++ b/test/unit/extension-path.spec.php
@@ -28,7 +28,7 @@ describe('Extension\Path', function() {
     describe('relativeResolvePath', function() {
         beforeEach(function() {
             $this->args->template = new Template('a', [], [], null, (new Template('b', [], ['path' => 'foo/b.phtml']))->reference);
-            $this->resolve = stack([relativeResolvePath(), idResolvePath()]);
+            $this->resolve = stack([idResolvePath(), relativeResolvePath()]);
         });
         it('resolves the name relative to the current_directory in context', function() {
             $resolve = $this->resolve;
@@ -54,9 +54,9 @@ describe('Extension\Path', function() {
     });
     describe('prefixResolvePath', function() {
         beforeEach(function() {
-            $this->resolve = stack([prefixResolvePath(['/foo', '/bar'], function() {
+            $this->resolve = stack([idResolvePath(), prefixResolvePath(['/foo', '/bar'], function() {
                 return true;
-            }), idResolvePath()]);
+            })]);
         });
         it('prefixes non absolute paths with a base path', function() {
             $path = ($this->resolve)($this->args->withPath('bar'));
@@ -71,12 +71,12 @@ describe('Extension\Path', function() {
     });
     describe('extResolvePath', function() {
         it('appends an extension to the name', function() {
-            $resolve = stack([extResolvePath('bar'), idResolvePath()]);
+            $resolve = stack([idResolvePath(), extResolvePath('bar')]);
             $path = $resolve($this->args->withPath('foo'));
             expect($path)->equal('foo.bar');
         });
         it('does not append the name if ext already exists', function() {
-            $resolve = stack([extResolvePath('bar'), idResolvePath()]);
+            $resolve = stack([idResolvePath(), extResolvePath('bar')]);
             $path = $resolve($this->args->withPath('foo.bar'));
             expect($path)->equal('foo.bar');
         });

--- a/test/unit/util.spec.php
+++ b/test/unit/util.spec.php
@@ -14,11 +14,9 @@ describe('Util', function() {
     describe('stack', function() {
         it('can stack a group of functions', function() {
             $handler = Util\stack([
+                Util\id(),
                 function($v, $next) {
                     return $next($v + 1) * 2;
-                },
-                function($v) {
-                    return $v;
                 }
             ]);
             expect($handler(2))->equal(6);
@@ -38,21 +36,11 @@ describe('Util', function() {
                 };
             };
             $group = Util\stackGroup([
+                $add(2),
                 $add(1),
-                $add(2)
             ]);
-            $stack = Util\stack([$group, Util\id()]);
+            $stack = Util\stack([Util\id(), $group]);
             expect($stack(0))->equal(3);
-        });
-    });
-    describe('prioritizeStacks', function() {
-        it('prioritizes stacks by index', function() {
-            $stacks = [
-                1 => [3],
-                -1 => [1],
-                0 => [2],
-            ];
-            expect(Util\sortStacks($stacks))->equal([1,2,3]);
         });
     });
     describe('joinPath', function() {


### PR DESCRIPTION
- `stack` and `compose` order has been adjusted to
  be more conventional and easier to use. In both
  cases, the first func will be executed last and
  last will be executed first. This flow encourages
  decoration and makes extension more natural since
  it is easier to append arrays than prepend them

Signed-off-by: RJ Garcia <rj@bighead.net>