### PR TITLE
Fixed the bug - argument 1 passed to stripPrefixNormalizeName

### DIFF
--- a/src/Extension/Path/PathExtension.php
+++ b/src/Extension/Path/PathExtension.php
@@ -9,12 +9,7 @@ final class PathExtension implements Plates\Extension
     public function register(Plates\Engine $plates) {
         $c = $plates->getContainer();
         $c->add('path.resolvePath.prefixes', function($c) {
-            $config = $c->get('config');
-
-            // wrap base dir in an array if not already
-            $base_dir = isset($config['base_dir']) ? $config['base_dir'] : null;
-            $base_dir = $base_dir ? (is_string($base_dir) ? [$base_dir] : $base_dir) : $base_dir;
-            return $base_dir;
+            return (array) ($c->get('config')['base_dir'] ?? []);
         });
         $c->addComposed('path.normalizeName', function($c) {
             return [


### PR DESCRIPTION
When trying to set `base_dir` as `null` or empty string in the constructor the following error is throwen:
```
Argument 1 passed to \League\Plates\Extension\Path\stripPrefixNormalizeName must be of the type array, null given
```