### PR TITLE
Change callback PhpDoc type to callable

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -188,7 +188,7 @@ class Engine
     /**
      * Register a new template function.
      * @param  string   $name;
-     * @param  callback $callback;
+     * @param  callable $callback;
      * @return Engine
      */
     public function registerFunction($name, $callback)

--- a/src/Template/Functions.php
+++ b/src/Template/Functions.php
@@ -18,7 +18,7 @@ class Functions
     /**
      * Add a new template function.
      * @param  string    $name;
-     * @param  callback  $callback;
+     * @param  callable  $callback;
      * @return Functions
      */
     public function add($name, $callback)


### PR DESCRIPTION
As discussed in #284 , this changes the callback type to callable in the PhpDoc comments.