### PR TITLE
Escape can take a null parameter php8.1

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -368,7 +368,7 @@ class Template
             $string = $this->batch($string, $functions);
         }
 
-        return htmlspecialchars($string, $flags, 'UTF-8');
+        return htmlspecialchars($string ?? '', $flags, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
PHP 8.1 htmlspecialchars no longer accepts a null parameter 
`php8.1 Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated` 
This fix allows you not to worry about the types of variables being passed 
The behavior is now the same as in php8.0