### PR TITLE
Don't leak variables from the rendering process into templates

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -73,6 +73,12 @@ class Template
     protected $layoutData;
 
     /**
+     * The output buffering level when rendering.
+     * @var int
+     */
+    private $level;
+
+    /**
      * Create new Template instance.
      * @param Engine $engine
      * @param string $name
@@ -161,13 +167,11 @@ class Template
         unset($data);
         extract($this->data);
 
-        $path = ($this->engine->getResolveTemplatePath())($this->name);
-
         try {
-            $level = ob_get_level();
+            $this->level = ob_get_level();
             ob_start();
 
-            include $path;
+            include ($this->engine->getResolveTemplatePath())($this->name);
 
             $content = ob_get_clean();
 
@@ -179,7 +183,7 @@ class Template
 
             return $content;
         } catch (Throwable $e) {
-            while (ob_get_level() > $level) {
+            while (ob_get_level() > $this->level) {
                 ob_end_clean();
             }
 

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -39,6 +39,17 @@ class TemplateTest extends TestCase
         $this->assertSame('JONATHAN', $this->template->render());
     }
 
+    public function testCleanEnvironment()
+    {
+        vfsStream::create(
+            array(
+                'template.php' => '<?= count(get_defined_vars()) ?>',
+            )
+        );
+
+        $this->assertSame('0', $this->template->render());
+    }
+
     public function testAssignData()
     {
         vfsStream::create(


### PR DESCRIPTION
This PR fixes #301 where the rendering process variables `$level` (nested template depth) and `$path` are removed from the template's local scope. `$path` got removed by not generating a temporary variable but `$level` is now stored in a class attribute dedicated to the nesting level during the rendering process.