### PR TITLE
Added sections inheritance of fetched templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ doc/public
 doc/data/versions.json
 .generated
 .phpunit.result.cache
+.idea/.gitignore
+.idea/modules.xml
+.idea/php-test-framework.xml
+.idea/php.xml
+.idea/phpunit.xml
+.idea/plates.iml
+.idea/vcs.xml
+composer.phar

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -342,20 +342,23 @@ class Template
         }
 
         // otherwise we need to consider the incoming section mode
-        switch ($sectionMode) {
-
-            case self::SECTION_MODE_REWRITE:
+        if ($sectionMode === self::SECTION_MODE_REWRITE) {
                 $this->sections[$sectionName] = $sectionContent;
-                break;
+            return;
+        }
 
-            case self::SECTION_MODE_APPEND:
-                $this->sections[$sectionName] .= $sectionContent;
-                break;
+        $existingContent = array_key_exists($sectionName, $this->sections)
+            ? $this->sections[$sectionName]
+            : '';
 
-            case self::SECTION_MODE_PREPEND:
-                $this->sections[$sectionName] = $sectionContent.$this->sections[$sectionName];
-                break;
+        if ($sectionMode === self::SECTION_MODE_APPEND) {
+            $this->sections[$sectionName] = $existingContent.$sectionContent;
+            return;
+        }
 
+        if ($sectionMode === self::SECTION_MODE_PREPEND) {
+            $this->sections[$sectionName] = $sectionContent.$existingContent;
+            return;
         }
     }
 

--- a/src/Template/TemplateSection.php
+++ b/src/Template/TemplateSection.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace League\Plates\Template;
+
+/**
+ * Defines the object format of the data target 
+ * to be rendered in a Template's Section.
+ */
+class TemplateSection
+{
+    /**
+     * Section mode.
+     *
+     * @var int
+     */
+    protected $mode;
+
+    /**
+     * Section content.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * Section name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string  $name
+     * @param ?string $content
+     * @param ?int    $mode
+     */
+    public function __construct(string $name, $content = '', $mode = Template::SECTION_MODE_REWRITE)
+    {
+        $this->name = $name;
+        $this->content = $content;
+        $this->mode = $mode;
+    }
+
+    /**
+     * @param  string $content
+     * @param  int    $mode
+     * @return void
+     */
+    public function add(string $content, int $mode)
+    {
+        $this->mode = $mode;
+
+        // if this template doesn't have that section, so we just add it.
+        if (empty($this->content)) {
+            $this->content = $content;
+            return;
+        }
+
+        // otherwise we need to consider the incoming section mode
+        if ($mode === Template::SECTION_MODE_REWRITE) {
+            $this->content = $content;
+            return;
+        }
+
+        if ($mode === Template::SECTION_MODE_APPEND) {
+            $this->content = $this->content . $content;
+            return;
+        }
+
+        if ($mode === Template::SECTION_MODE_PREPEND) {
+            $this->content = $content . $this->content;
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMode(): int
+    {
+        return $this->mode;
+    }
+}

--- a/src/Template/TemplateSectionCollection.php
+++ b/src/Template/TemplateSectionCollection.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace League\Plates\Template;
+
+use ArrayAccess;
+use InvalidArgumentException;
+
+/**
+ * Collection of TemplateSections that can be used to fill Template's Sections.
+ * Here is defined a common API for merging Template Section data.
+ * NOTE: currently this is not iterable, so do not try this in a foreach.
+ */
+class TemplateSectionCollection implements ArrayAccess
+{
+    /**
+     * @var array<string, TemplateSection>
+     */
+    private $sections = array();
+
+    /**
+     * @param string $offset
+     *
+     * @return bool
+     */
+    public function has(string $offset): bool
+    {
+        return array_key_exists($offset, $this->sections);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return TemplateSection
+     */
+    public function get(string $offset)
+    {
+        return $this->sections[$offset];
+    }
+
+    /**
+     * @param string               $offset
+     * @param TemplateSection|null $value
+     *
+     * @return void
+     */
+    public function set(string $offset, $value)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        if (!($value instanceof TemplateSection) && $value != null) {
+            throw new InvalidArgumentException('The section set must be of type TemplateSection.');
+        }
+        $this->sections[$offset] = $value;
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        return $this->has($offset);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return string
+     */
+    public function offsetGet($offset)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        return $this->get($offset)->getContent();
+    }
+
+    /**
+     * @param string $offset
+     * @param string $value
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        $this->add($offset, $value, Template::SECTION_MODE_REWRITE);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        $this->sections[$offset] = null;
+        unset($this->sections[$offset]);
+    }
+
+    /**
+     * Pushes the given section content to the sections array.
+     * You can use the $mode to merge the content to an existing
+     * content if that section content already exists.
+     *
+     * @param string $name
+     * @param string $content
+     * @param ?int   $mode
+     *
+     * @return void
+     */
+    public function add(string $name, string $content, $mode = Template::SECTION_MODE_APPEND) 
+    {
+        if ($this->has($name)) {
+            $this->sections[$name]->add($content, $mode);
+            return;
+        }
+        $this->sections[$name] = new TemplateSection($name, $content, $mode);
+    }
+
+    /**
+     * Merges another Template Sections collection into 
+     * this one taking in consideration the template 
+     * section's modes.
+     *
+     * @return void
+     */
+    public function merge(TemplateSectionCollection $templateSections)
+    {
+        foreach ($templateSections->sections as $section) {
+            $this->add(
+                $section->getName(), 
+                $section->getContent(),
+                $section->getMode()
+            );
+        }
+    }
+}

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -186,6 +186,69 @@ class TemplateTest extends TestCase
         $this->assertSame('See this instead!', $this->template->render());
     }
 
+    public function testInheritedSection()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->push("textSection") ?>See this! <?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->push("textSection") ?>See this too!<?php $this->stop() ?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this! See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionUnshift()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->push("textSection") ?>See this!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->unshift("textSection") ?>See this too! <?php $this->stop() ?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this too! See this!', $this->template->render());
+    }
+
+    public function testInheritedSectionUnshiftsParent()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->unshift("textSection") ?>See this! <?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->unshift("textSection") ?>See this too!<?php $this->stop() ?><?= $this->fetch("template-child")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this! See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionReplacement()
+    {
+        vfsStream::create(array(
+            'template-child.php' => '<?php $this->push("textSection") ?>See this!<?php $this->stop() ?>',
+            'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->start("textSection") ?>See this too!<?php $this->stop() ?>',
+            'layout.php' => '<?php echo $this->section("textSection") ?>',
+        ));
+
+        $this->assertSame('See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionReplacesParent()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->start("textSection") ?>See this replacement!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->start("textSection") ?> See this too!<?php $this->stop() ?><?= $this->fetch("template-child")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this replacement!', $this->template->render());
+    }
+
     public function testStartSectionWithInvalidName()
     {
         // The section name "content" is reserved.

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
 {
+    /**
+     * @var Template
+     */
     private $template;
 
     protected function setUp(): void


### PR DESCRIPTION
Closes #305

This PR partially addresses the case described in #305 , it still lacks considering the section mode of each of the appended sections where you can append, prepend or replace the sections entirely. Unfortunately we don't current store how the sections where filled in the template so it is currently impossible to know that during the inheritance in the parent template. My current best idea for that is to create yet a new property called `$sectionsAddedMode` so we can track per section name the mode used during the push/unshift/replace, e.g. `$sectionsAddedMode = [ 'head' => 1, 'appbar' => 1, 'footerScripts' => 2 ]`.