### PR TITLE
Use `new static` instead of `new self`

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -68,7 +68,7 @@ class Engine
     }
 
     public static function fromTheme(Theme $theme, string $fileExtension = 'php'): self {
-        $engine = new self(null, $fileExtension);
+        $engine = new static(null, $fileExtension);
         $engine->setResolveTemplatePath(new ResolveTemplatePath\ThemeResolveTemplatePath($theme));
         return $engine;
     }


### PR DESCRIPTION
This allows the `Engine` class to be more easily extended with additional functionality.