### PR TITLE
 Added sections inheritance of fetched templates while retaining mutation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ doc/public
 doc/data/versions.json
 .generated
 .phpunit.result.cache
+.idea/.gitignore
+.idea/modules.xml
+.idea/php-test-framework.xml
+.idea/php.xml
+.idea/phpunit.xml
+.idea/plates.iml
+.idea/vcs.xml
+composer.phar

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -262,10 +262,6 @@ class Template
             );
         }
 
-        if (!$this->sections->has($sectionName)) {
-            $this->sections[$sectionName] = '';
-        }
-
         $sectionContent = ob_get_clean();
 
         // if ob_clean failed for some reason let's just ignore the result

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -342,20 +342,23 @@ class Template
         }
 
         // otherwise we need to consider the incoming section mode
-        switch ($sectionMode) {
-
-            case self::SECTION_MODE_REWRITE:
+        if ($sectionMode === self::SECTION_MODE_REWRITE) {
                 $this->sections[$sectionName] = $sectionContent;
-                break;
+            return;
+        }
 
-            case self::SECTION_MODE_APPEND:
-                $this->sections[$sectionName] .= $sectionContent;
-                break;
+        $existingContent = array_key_exists($sectionName, $this->sections)
+            ? $this->sections[$sectionName]
+            : '';
 
-            case self::SECTION_MODE_PREPEND:
-                $this->sections[$sectionName] = $sectionContent.$this->sections[$sectionName];
-                break;
+        if ($sectionMode === self::SECTION_MODE_APPEND) {
+            $this->sections[$sectionName] = $existingContent.$sectionContent;
+            return;
+        }
 
+        if ($sectionMode === self::SECTION_MODE_PREPEND) {
+            $this->sections[$sectionName] = $sectionContent.$existingContent;
+            return;
         }
     }
 

--- a/src/Template/TemplateSection.php
+++ b/src/Template/TemplateSection.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace League\Plates\Template;
+
+/**
+ * Defines the object format of the data target 
+ * to be rendered in a Template's Section.
+ */
+class TemplateSection
+{
+    /**
+     * Section mode.
+     *
+     * @var int
+     */
+    protected $mode;
+
+    /**
+     * Section content.
+     *
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * Section name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string  $name
+     * @param ?string $content
+     * @param ?int    $mode
+     */
+    public function __construct(string $name, $content = '', $mode = Template::SECTION_MODE_REWRITE)
+    {
+        $this->name = $name;
+        $this->content = $content;
+        $this->mode = $mode;
+    }
+
+    /**
+     * @param  string $content
+     * @param  int    $mode
+     * @return void
+     */
+    public function add(string $content, int $mode)
+    {
+        $this->mode = $mode;
+
+        // if this template doesn't have that section, so we just add it.
+        if (empty($this->content)) {
+            $this->content = $content;
+            return;
+        }
+
+        // otherwise we need to consider the incoming section mode
+        if ($mode === Template::SECTION_MODE_REWRITE) {
+            $this->content = $content;
+            return;
+        }
+
+        if ($mode === Template::SECTION_MODE_APPEND) {
+            $this->content = $this->content . $content;
+            return;
+        }
+
+        if ($mode === Template::SECTION_MODE_PREPEND) {
+            $this->content = $content . $this->content;
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMode(): int
+    {
+        return $this->mode;
+    }
+}

--- a/src/Template/TemplateSectionCollection.php
+++ b/src/Template/TemplateSectionCollection.php
@@ -138,11 +138,11 @@ class TemplateSectionCollection implements ArrayAccess
     public function merge(TemplateSectionCollection $templateSections)
     {
         foreach ($templateSections->sections as $section) {
-            $this->add(
-                $section->getName(), 
-                $section->getContent(),
-                $section->getMode()
-            );
+            if (isset($this->sections[$section->getName()])) {
+                $this->sections[$section->getName()]->merge($section);
+            } else {
+                $this->sections[$section->getName()] = $section;
+            }
         }
     }
 }

--- a/src/Template/TemplateSectionCollection.php
+++ b/src/Template/TemplateSectionCollection.php
@@ -72,7 +72,7 @@ class TemplateSectionCollection implements ArrayAccess
      *
      * @return string
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): string
     {
         if (!is_string($offset)) {
             throw new InvalidArgumentException('The desired section offset must be a string.');
@@ -99,7 +99,7 @@ class TemplateSectionCollection implements ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (!is_string($offset)) {
             throw new InvalidArgumentException('The desired section offset must be a string.');

--- a/src/Template/TemplateSectionCollection.php
+++ b/src/Template/TemplateSectionCollection.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace League\Plates\Template;
+
+use ArrayAccess;
+use InvalidArgumentException;
+
+/**
+ * Collection of TemplateSections that can be used to fill Template's Sections.
+ * Here is defined a common API for merging Template Section data.
+ * NOTE: currently this is not iterable, so do not try this in a foreach.
+ */
+class TemplateSectionCollection implements ArrayAccess
+{
+    /**
+     * @var array<string, TemplateSection>
+     */
+    private $sections = array();
+
+    /**
+     * @param string $offset
+     *
+     * @return bool
+     */
+    public function has(string $offset): bool
+    {
+        return array_key_exists($offset, $this->sections);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return TemplateSection
+     */
+    public function get(string $offset)
+    {
+        return $this->sections[$offset];
+    }
+
+    /**
+     * @param string               $offset
+     * @param TemplateSection|null $value
+     *
+     * @return void
+     */
+    public function set(string $offset, $value)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        if (!($value instanceof TemplateSection) && $value != null) {
+            throw new InvalidArgumentException('The section set must be of type TemplateSection.');
+        }
+        $this->sections[$offset] = $value;
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        return $this->has($offset);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return string
+     */
+    public function offsetGet($offset)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        return $this->get($offset)->getContent();
+    }
+
+    /**
+     * @param string $offset
+     * @param string $value
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        $this->add($offset, $value, Template::SECTION_MODE_REWRITE);
+    }
+
+    /**
+     * @param string $offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if (!is_string($offset)) {
+            throw new InvalidArgumentException('The desired section offset must be a string.');
+        }
+        $this->sections[$offset] = null;
+        unset($this->sections[$offset]);
+    }
+
+    /**
+     * Pushes the given section content to the sections array.
+     * You can use the $mode to merge the content to an existing
+     * content if that section content already exists.
+     *
+     * @param string $name
+     * @param string $content
+     * @param ?int   $mode
+     *
+     * @return void
+     */
+    public function add(string $name, string $content, $mode = Template::SECTION_MODE_APPEND) 
+    {
+        if ($this->has($name)) {
+            $this->sections[$name]->add($content, $mode);
+            return;
+        }
+        $this->sections[$name] = new TemplateSection($name, $content, $mode);
+    }
+
+    /**
+     * Merges another Template Sections collection into 
+     * this one taking in consideration the template 
+     * section's modes.
+     *
+     * @return void
+     */
+    public function merge(TemplateSectionCollection $templateSections)
+    {
+        foreach ($templateSections->sections as $section) {
+            $this->add(
+                $section->getName(), 
+                $section->getContent(),
+                $section->getMode()
+            );
+        }
+    }
+}

--- a/src/Template/TemplateSectionMutation.php
+++ b/src/Template/TemplateSectionMutation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace League\Plates\Template;
+
+/**
+ * Defines the object format of a template mutation
+ * across template and nested templates to be rendered
+ * as final Template's Section.
+ */
+class TemplateSectionMutation
+{
+    public $mode;
+
+    public $content;
+
+    public function __construct($mode, $content)
+    {
+        $this->mode = $mode;
+        $this->content = $content;
+    }
+}

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -186,6 +186,69 @@ class TemplateTest extends TestCase
         $this->assertSame('See this instead!', $this->template->render());
     }
 
+    public function testInheritedSection()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->push("textSection") ?>See this! <?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->push("textSection") ?>See this too!<?php $this->stop() ?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this! See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionUnshift()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->push("textSection") ?>See this!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->unshift("textSection") ?>See this too! <?php $this->stop() ?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this too! See this!', $this->template->render());
+    }
+
+    public function testInheritedSectionUnshiftsParent()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->unshift("textSection") ?>See this! <?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->unshift("textSection") ?>See this too!<?php $this->stop() ?><?= $this->fetch("template-child")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this! See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionReplacement()
+    {
+        vfsStream::create(array(
+            'template-child.php' => '<?php $this->push("textSection") ?>See this!<?php $this->stop() ?>',
+            'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->start("textSection") ?>See this too!<?php $this->stop() ?>',
+            'layout.php' => '<?php echo $this->section("textSection") ?>',
+        ));
+
+        $this->assertSame('See this too!', $this->template->render());
+    }
+
+    public function testInheritedSectionReplacesParent()
+    {
+        vfsStream::create(
+            array(
+                'template-child.php' => '<?php $this->start("textSection") ?>See this replacement!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->start("textSection") ?> See this too!<?php $this->stop() ?><?= $this->fetch("template-child")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this replacement!', $this->template->render());
+    }
+
     public function testStartSectionWithInvalidName()
     {
         // The section name "content" is reserved.

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
 {
+    /**
+     * @var Template
+     */
     private $template;
 
     protected function setUp(): void

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -228,12 +228,12 @@ class TemplateTest extends TestCase
     public function testInheritedSectionReplacement()
     {
         vfsStream::create(array(
-            'template-child.php' => '<?php $this->push("textSection") ?>See this!<?php $this->stop() ?>',
-            'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->start("textSection") ?>See this too!<?php $this->stop() ?>',
+            'template-child.php' => '<?php $this->push("textSection") ?> See this too!<?php $this->stop() ?>',
+            'template.php' => '<?php $this->layout("layout")?><?= $this->fetch("template-child")?><?php $this->start("textSection") ?>See this!<?php $this->stop() ?>',
             'layout.php' => '<?php echo $this->section("textSection") ?>',
         ));
 
-        $this->assertSame('See this too!', $this->template->render());
+        $this->assertSame('See this! See this too!', $this->template->render());
     }
 
     public function testInheritedSectionReplacesParent()
@@ -247,6 +247,34 @@ class TemplateTest extends TestCase
         );
 
         $this->assertSame('See this replacement!', $this->template->render());
+    }
+
+    public function testInheritedSectionReplacesParentAndPush()
+    {
+        vfsStream::create(
+            array(
+                'template-child1.php' => '<?php $this->start("textSection") ?>See this replacement!<?php $this->stop() ?>',
+                'template-child2.php' => '<?php $this->push("textSection") ?> See this content pushed!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->start("textSection") ?>Not see this!<?php $this->stop() ?><?= $this->fetch("template-child1")?><?= $this->fetch("template-child2")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this replacement! See this content pushed!', $this->template->render());
+    }
+
+    public function testInheritedSectionPushAndReplacesParent()
+    {
+        vfsStream::create(
+            array(
+                'template-child1.php' => '<?php $this->push("textSection") ?> See this content pushed!<?php $this->stop() ?>',
+                'template-child2.php' => '<?php $this->start("textSection") ?>See this replacement!<?php $this->stop() ?>',
+                'template.php' => '<?php $this->layout("layout")?><?php $this->start("textSection") ?>Not see this!<?php $this->stop() ?><?= $this->fetch("template-child1")?><?= $this->fetch("template-child2")?>',
+                'layout.php' => '<?php echo $this->section("textSection") ?>',
+            )
+        );
+
+        $this->assertSame('See this replacement! See this content pushed!', $this->template->render());
     }
 
     public function testStartSectionWithInvalidName()


### PR DESCRIPTION
Based on #306, implements section as history of mutation. There is an uncertainty in my implementation details: whether to allow multiple mutation with `Template::SECTION_MODE_REWRITE` mode or just break at the first attempt or some other alternative behavior.