### PR TITLE
Make default escape method overridable via extensions

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -360,6 +360,10 @@ class Template
     {
         static $flags;
 
+        if ($this->engine->doesFunctionExist('escape')) {
+            return $this->engine->getFunction('escape')->call($this, func_get_args());
+        }
+
         if (!isset($flags)) {
             $flags = ENT_QUOTES | (defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0);
         }


### PR DESCRIPTION
A more elegant solution (now implemented in https://github.com/thephpleague/plates/pull/314) would be to define the `escape` and `e` helper functions in an extension registered by default.
In this way it would be easier for developers to create version of escape methods with different signatures. I would keep the batch method in the Template class anyway. 