### PR TITLE
Simplify data return type and permit inheritance of data over layout and fetch 

### DIFF
--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -311,9 +311,9 @@ class Template
      * @param  array  $data
      * @return string
      */
-    public function fetch($name, array $data = array(), bool $only = true)
+    public function fetch($name, array $data = array(), bool $useTemplateData = false)
     {
-        return $this->engine->render($name, $only ? $data : array_merge($this->data, $data));
+        return $this->engine->render($name, $useTemplateData ? array_merge($this->data, $data) : $data);
     }
 
     /**
@@ -322,9 +322,9 @@ class Template
      * @param  array  $data
      * @return null
      */
-    public function insert($name, array $data = array())
+    public function insert($name, array $data = array(), bool $useTemplateData = false)
     {
-        echo $this->engine->render($name, $data);
+        echo $this->fetch($name, $data, $useTemplateData);
     }
 
     /**

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -110,7 +110,7 @@ class Template
     /**
      * Assign or get template data.
      * @param  array $data
-     * @return mixed
+     * @return array
      */
     public function data(array $data = null)
     {
@@ -118,7 +118,7 @@ class Template
             return $this->data;
         }
 
-        $this->data = array_merge($this->data, $data);
+        return $this->data = array_merge($this->data, $data);
     }
 
     /**
@@ -196,7 +196,7 @@ class Template
     public function layout($name, array $data = array())
     {
         $this->layoutName = $name;
-        $this->layoutData = $data;
+        $this->layoutData = array_merge($this->data, $data);
     }
 
     /**
@@ -311,9 +311,9 @@ class Template
      * @param  array  $data
      * @return string
      */
-    public function fetch($name, array $data = array())
+    public function fetch($name, array $data = array(), bool $only = true)
     {
-        return $this->engine->render($name, $data);
+        return $this->engine->render($name, $only ? $data : array_merge($this->data, $data));
     }
 
     /**


### PR DESCRIPTION
This commit contains 2 propositions without BC break : 
* Simplify `template->data()` return type (minor)
* permit inheritance of data over layout (like twig, maybe major)
